### PR TITLE
fix: illegal parameter variables transform  and options parameters sort

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -23,7 +23,7 @@ export default async function main({
     }
     await fs.mkdirsSync(folder)
     if (!requestPath && needExports) {
-      writeRequest(templates, folder)
+      await writeRequest(templates, folder)
     }
     const { models, services} = handlePaths(res, paths)
     try {

--- a/src/core/interfaces/index.d.ts
+++ b/src/core/interfaces/index.d.ts
@@ -12,4 +12,5 @@ export interface TypeItem {
   description: string
   isOption?: boolean
   imports?: string[]
+  alias?: string // when name is illegal variable
 }

--- a/src/core/interfaces/index.ts
+++ b/src/core/interfaces/index.ts
@@ -1,10 +1,12 @@
-import { Definition, Items, Parameter } from '../types'
+import { Definition, Parameter } from '../types'
 import * as Types from './index.d'
+import { VARIABLES_ILLEGAL_REG } from '../utils/const'
+
 
 /**
  * fix property with - in object bugs
  */
-export const propertyGetter: (property: string) => string = property => /\-/g.test(property) ? `'${property}'` : property
+export const propertyGetter: (property: string) => string = property => VARIABLES_ILLEGAL_REG.test(property) ? "'" + property + "'" : property
 
 /**
  * @param {definitions} swagger definitions

--- a/src/core/services/index.d.ts
+++ b/src/core/services/index.d.ts
@@ -18,7 +18,5 @@ export interface BaseRequest {
   body?: TypeItem[]
   formData?: TypeItem[]
   url: string
-  hasQuery: boolean
-  hasBody: boolean
-  hasFormData: boolean
+  header?: TypeItem[]
 }

--- a/src/core/services/index.spec.ts
+++ b/src/core/services/index.spec.ts
@@ -1,4 +1,4 @@
-import { getControllers, convertService, getParameters, getResponseType, getServiceMapData, handlerBasePath } from './index'
+import { getControllers, convertService, getParameters, getResponseType, getServiceMapData, handlerBasePath, createAlias } from './index'
 import { fetchApiJson } from '../utils/share'
 import { Parameter } from '../types'
 
@@ -33,6 +33,10 @@ describe('services tests',  () => {
 
   })
 
+  test('create alias replace illegal word with "-"', () => {
+    expect(createAlias('user-name')).toBe('user_name')
+  })
+
   // TODO: getparameters getResponseType getServiceName
 
   test('getparameters', () => {
@@ -45,15 +49,20 @@ describe('services tests',  () => {
       "schema": {
         "$ref": "#/definitions/AchievementTransferAddRequest"
         }
+      },
+      {
+        "name": "user-name",
+        "in": "header",
+        "description": "user-name",
+        "required": false,
+        "type": "string"
       }
-      ]
-    expect(
-      getParameters(parameters)
-    ).toHaveProperty('parametersRecord', {
-      'body':
-        [{"description": "request", "imports": ["AchievementTransferAddRequest"], "isOption": false, "name": "request", "type": "AchievementTransferAddRequest"}]
+    ]
 
-    })
+    const { parametersRecord: params, parameters: parametersList } = getParameters(parameters)
+    expect(parametersList[1]).toHaveProperty('alias', 'user_name')
+    expect(params.body).toHaveLength(1)
+    expect(params.header).toHaveLength(1)
   })
 
   test('getResponseType should log response type', () => {
@@ -72,4 +81,5 @@ describe('services tests',  () => {
   })
 
 })
+
 

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -10,8 +10,10 @@
  */
 import { Swagger, Tag, Path, SwaggerResponses, Parameter, ParameterIn } from '../types'
 import { ServiceController,  } from './index.d'
-import { formatTypes } from '../interfaces'
+import { formatTypes, propertyGetter } from '../interfaces'
 import { TypeItem } from '../interfaces/index.d'
+import { VARIABLES_ILLEGAL_REG } from '../utils/const'
+
 /**
  * A list of tags used by the specification with additional metadata.
  * The order of the tags can be used to reflect on their order by the parsing tools.
@@ -61,7 +63,6 @@ export function getServiceMapData(
   controllerMap:  Record<string, ServiceController>
 ) {
   const methods = swagger.paths[path]
-  const basePath = handlerBasePath(swagger.basePath)
   Object.keys(methods).forEach(method => {
     const methodWrapper = methods[method]
     if (controllerMap[methodWrapper.tags[0]]) {
@@ -89,9 +90,6 @@ export function getServiceMapData(
           ? response.type : response,
         ...parametersRecord,
         parameters,
-        hasQuery,
-        hasBody,
-        hasFormData,
       }
       tag.requests.push(request)
     }
@@ -114,12 +112,15 @@ export function getResponseType(responses: SwaggerResponses){
   return responses['200'] && responses['200'].schema ? formatTypes(responses['200'].schema) : 'any'
 }
 
+export const createAlias = (name: string): string | undefined => VARIABLES_ILLEGAL_REG.test(name) ? name.replace(VARIABLES_ILLEGAL_REG, '_') : undefined
+
 /**
 * here we need to notice not like body, formData, path, query should
 * be a collection types
 * eg: body: `{ key: type, key1: type1} `
 * query formData path: `key: type, key1: type1`
 * *notice schema: https://swagger.io/specification/v2/#parameterObject
+*
  */
 export function getParameters(
   parameters:Parameter[]
@@ -143,22 +144,25 @@ export function getParameters(
     if (model) {
       imports.push(...model)
     }
-    const param = {
-      name: parameter.name,
+    const param: TypeItem = {
+      /**
+       * magic code create alias must be first, then format name
+       * it maybe regexp bugs
+       */
+      alias: createAlias(parameter.name),
+      name: propertyGetter(parameter.name),
       type,
       imports: model,
       isOption: !parameter.required,
-      description: parameter.description
+      description: parameter.description,
+
     }
     parametersRecord[parameter.in].push(param)
     return param
-  })
+  }).sort((a, b) => Number(!!a.isOption) - Number(!!b.isOption)) // optional params append at the tail
   return {
     parametersRecord,
     parameters: params,
     imports,
-    hasQuery: !!parametersRecord.query && parametersRecord.query.length > 0,
-    hasBody: !!parametersRecord.body && parametersRecord.body.length > 0,
-    hasFormData: !!parametersRecord.formData && parametersRecord.formData.length > 0,
   }
 }

--- a/src/core/utils/const.spec.ts
+++ b/src/core/utils/const.spec.ts
@@ -1,0 +1,13 @@
+import { RESERVED_WORDS, VARIABLES_ILLEGAL_REG, VARIABLES_SEPARATOR } from './const'
+
+it('reserved words should include delete ', () => {
+  expect(RESERVED_WORDS).toContain('delete')
+})
+
+it('variables illegal reg should match "-"', () => {
+  expect(VARIABLES_ILLEGAL_REG.test('user-name')).toBe(true)
+})
+
+it('legal separator is "_" ', () => {
+  expect(VARIABLES_SEPARATOR).toBe('_')
+})

--- a/src/core/utils/const.ts
+++ b/src/core/utils/const.ts
@@ -1,0 +1,61 @@
+/**
+ * @description javascript reserved words
+ */
+export const RESERVED_WORDS = [
+  'arguments',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'eval',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'instanceof',
+  'interface',
+  'let',
+  'new',
+  'null',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'return',
+  'static',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield'
+]
+/**
+ * @more https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_Types
+ * @description illegal words in varibles
+ * @example: ❌ user-name (user name) user.name
+ * @example: ✅ user_name $user_name
+ */
+export const VARIABLES_ILLEGAL_REG = /[^\w|^\$]/g
+
+export const VARIABLES_SEPARATOR = '_'

--- a/src/core/utils/file.spec.ts
+++ b/src/core/utils/file.spec.ts
@@ -20,8 +20,8 @@ describe('files tests', () => {
       name: 'render_test',
       author: 'dylan'
     }
-    await writeMustacheFile(testTemp, testData, '../.test')
-    expect(mustache.render).toBeCalledWith(testTemp, testData)
+    await writeMustacheFile(testTemp, testData, '../.test', {})
+    expect(mustache.render).toBeCalledWith(testTemp, testData, {})
     expect(fs.writeFileSync).toBeCalled()
     // @ts-ignore
     writeMustacheFile(testTemp, null, '../.test').catch(err => expect(err).toBeDefined())

--- a/src/core/utils/files.ts
+++ b/src/core/utils/files.ts
@@ -6,9 +6,9 @@ const log = console.log
 export async function writeMustacheFile(temp: string, view: {
   name: string
   [key: string]: any
-}, src: string) {
+}, src: string, templateMap?: Record<string, string> ) {
   try {
-    const modelData = mustache.render(temp, view)
+    const modelData = mustache.render(temp, view, templateMap || {})
     const file = path.join(src, `./${view.name}.ts`)
     await fs.writeFileSync(
       file,

--- a/src/core/utils/registerTemplate.spec.ts
+++ b/src/core/utils/registerTemplate.spec.ts
@@ -7,9 +7,10 @@ test('base64 decoder', () => {
   const base64 = 'QmFzZTY0IEVuY29kaW5nIGluIE5vZGUuanM=';
   expect(decodeBase64(base64)).toBe('Base64 Encoding in Node.js')
 })
-test('registerTemplates should return templates', () => {
-  expect(registerTemplates()).toHaveProperty('index')
-  expect(registerTemplates()).toHaveProperty('request')
-  expect(registerTemplates()).toHaveProperty('model')
-  expect(registerTemplates()).toHaveProperty('utils')
+test('registerTemplates should return templates',  () => {
+  const templates = registerTemplates()
+  expect(templates).toHaveProperty('index')
+  expect(templates).toHaveProperty('request')
+  expect(templates).toHaveProperty('model')
+  expect(templates).toHaveProperty('utils')
 })

--- a/src/core/utils/registerTemplate.ts
+++ b/src/core/utils/registerTemplate.ts
@@ -3,6 +3,8 @@ import model from '../../templates/model.mustache'
 import request from '../../templates/request.mustache'
 import service from '../../templates/service.mustache'
 import utils from '../../templates/utils.mustache'
+import alias from '../../templates/alias.mustache'
+import parameters from '../../templates/parameters.mustache'
 
 export interface Templates {
   index: string
@@ -10,6 +12,8 @@ export interface Templates {
   request: string
   service: string
   utils: string
+  alias: string
+  parameters: string
 }
 export function decodeBase64(base64String: string): string {
   if (typeof base64String !== 'string') return ''
@@ -24,5 +28,7 @@ export function registerTemplates(): Templates {
     request: decodeBase64(request),
     service: decodeBase64(service),
     utils: decodeBase64(utils),
+    alias: decodeBase64(alias),
+    parameters: decodeBase64(parameters),
   }
 }

--- a/src/core/utils/writeServices.spec.ts
+++ b/src/core/utils/writeServices.spec.ts
@@ -27,7 +27,10 @@ describe('writeServices tests',() => {
       imports: [],
       requests: [],
       requestPath: '.'
-    }, '../.test/services')
+    }, '../.test/services', {
+      parameters: templates.parameters,
+      alias: templates.alias
+    })
     let error = jest.spyOn(global.console, 'error')
     // @ts-ignore
     await writeServices({}, null, '')

--- a/src/core/utils/writeServices.ts
+++ b/src/core/utils/writeServices.ts
@@ -11,15 +11,18 @@ export async function writeServices(
   try {
     await fs.mkdirsSync(path + '/services')
     const res = await Promise.all(
-      services.map(service => 
+      services.map(service =>
         writeMustacheFile(templates.service, {
           ...service,
           requestPath
-        }, path + '/services')
+        }, path + '/services', {
+          parameters: templates.parameters,
+          alias: templates.alias
+        })
       )
     )
   } catch(err) {
     console.error(err)
   }
-  
+
 }

--- a/src/templates/alias.mustache
+++ b/src/templates/alias.mustache
@@ -1,0 +1,6 @@
+{{^alias}}
+{{{name}}},
+{{/alias}}
+{{#alias}}
+{{{name}}}: {{.}},
+{{/alias}}

--- a/src/templates/model.mustache
+++ b/src/templates/model.mustache
@@ -15,6 +15,6 @@ export default interface {{name}}{{#extends}} extends {{extends}}{{/extends}} {
    * @description {{description}}
    */
   {{/description}}
-  '{{name}}'{{#isOption}}?{{/isOption}}: {{&type}}
+  {{name}}{{#isOption}}?{{/isOption}}: {{&type}}
   {{/types}}
 }

--- a/src/templates/parameters.mustache
+++ b/src/templates/parameters.mustache
@@ -1,0 +1,11 @@
+{{#description}}
+/**
+  * @description {{description}}
+  */
+{{/description}}
+{{#alias}}
+{{{.}}}{{#isOption}}?{{/isOption}}: {{&type}},
+{{/alias}}
+{{^alias}}
+{{{name}}}{{#isOption}}?{{/isOption}}: {{&type}},
+{{/alias}}

--- a/src/templates/service.mustache
+++ b/src/templates/service.mustache
@@ -21,35 +21,39 @@ export default class {{name}} {
   {{/description}}
   public static {{name}} = async (
     {{#parameters}}
-    {{#description}}
-    /**
-     * @description {{description}}
-     */
-    {{/description}}
-    {{name}}{{#isOption}}?{{/isOption}}: {{&type}},
+    {{>parameters}}
     {{/parameters}}
   ){{#responseType}}:Promise<{{{responseType}}}>{{/responseType}} => {
     const res = await _request{{#responseType}}<{{{responseType}}}>{{/responseType}}(`{{&url}}`, {
       method: '{{method}}',
-      {{#hasBody}}
+      {{#header.length}}
+      header: {
+        {{#header}}
+        {{>alias}}
+        {{/header}}
+      },
+      {{/header.length}}
+      {{#body.length}}
       {{#body}}
-      body: {{name}},
+      body: {
+        {{>alias}}
+      },
       {{/body}}
-      {{/hasBody}}
-      {{#hasQuery}}
+      {{/body.length}}
+      {{#query.length}}
       query: {
       {{#query}}
-        {{name}},
+        {{>alias}}
       {{/query}}
       },
-      {{/hasQuery}}
-      {{#hasFormData}}
+      {{/query.length}}
+      {{#formData.length}}
       formData: {
       {{#formData}}
-        {{name}},
+        {{>alias}}
       {{/formData}}
       },
-      {{/hasFormData}}
+      {{/formData.length}}
     })
     return res
   }

--- a/src/templates/service.mustache
+++ b/src/templates/service.mustache
@@ -27,7 +27,7 @@ export default class {{name}} {
     const res = await _request{{#responseType}}<{{{responseType}}}>{{/responseType}}(`{{&url}}`, {
       method: '{{method}}',
       {{#header.length}}
-      header: {
+      headers: {
         {{#header}}
         {{>alias}}
         {{/header}}


### PR DESCRIPTION
- transform parameter variables error, such as: `user-name` to `user_name`
- options parameters sorted 
```typescript
function example(option?: string, param: string) {}

// fix ✅
function example(param: string, option?: string) {}


```