### PR TITLE
fix: regexp with global flag stores a lastIndex from the previous match

### DIFF
--- a/src/core/interfaces/index.ts
+++ b/src/core/interfaces/index.ts
@@ -6,7 +6,7 @@ import { VARIABLES_ILLEGAL_REG } from '../utils/const'
 /**
  * fix property with - in object bugs
  */
-export const propertyGetter: (property: string) => string = property => VARIABLES_ILLEGAL_REG.test(property) ? "'" + property + "'" : property
+export const propertyGetter: (property: string) => string = property => property.search(VARIABLES_ILLEGAL_REG) > -1 ? "'" + property + "'" : property
 
 /**
  * @param {definitions} swagger definitions

--- a/src/core/services/index.spec.ts
+++ b/src/core/services/index.spec.ts
@@ -54,12 +54,13 @@ describe('services tests',  () => {
         "name": "user-name",
         "in": "header",
         "description": "user-name",
-        "required": false,
+        "required": true,
         "type": "string"
       }
     ]
 
     const { parametersRecord: params, parameters: parametersList } = getParameters(parameters)
+    console.log(params.header)
     expect(parametersList[1]).toHaveProperty('alias', 'user_name')
     expect(params.body).toHaveLength(1)
     expect(params.header).toHaveLength(1)

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -71,9 +71,6 @@ export function getServiceMapData(
         parametersRecord,
         imports,
         parameters,
-        hasQuery,
-        hasBody,
-        hasFormData,
       } = getParameters(methodWrapper.parameters)
       tag.imports.push(...(imports || []))
       // get responsetype
@@ -112,7 +109,7 @@ export function getResponseType(responses: SwaggerResponses){
   return responses['200'] && responses['200'].schema ? formatTypes(responses['200'].schema) : 'any'
 }
 
-export const createAlias = (name: string): string | undefined => VARIABLES_ILLEGAL_REG.test(name) ? name.replace(VARIABLES_ILLEGAL_REG, '_') : undefined
+export const createAlias = (name: string): string | undefined => name.search(VARIABLES_ILLEGAL_REG) > - 1 ? name.replace(VARIABLES_ILLEGAL_REG, '_') : undefined
 
 /**
 * here we need to notice not like body, formData, path, query should
@@ -144,11 +141,8 @@ export function getParameters(
     if (model) {
       imports.push(...model)
     }
+    console.log(parameter.name, parameter.name.search(VARIABLES_ILLEGAL_REG), createAlias(parameter.name) )
     const param: TypeItem = {
-      /**
-       * magic code create alias must be first, then format name
-       * it maybe regexp bugs
-       */
       alias: createAlias(parameter.name),
       name: propertyGetter(parameter.name),
       type,

--- a/src/core/utils/const.ts
+++ b/src/core/utils/const.ts
@@ -55,7 +55,8 @@ export const RESERVED_WORDS = [
  * @description illegal words in varibles
  * @example: ❌ user-name (user name) user.name
  * @example: ✅ user_name $user_name
+ * @notice Regexp.test with save lastIndex
  */
-export const VARIABLES_ILLEGAL_REG = /[^\w|^\$]/g
+export const VARIABLES_ILLEGAL_REG =/[^\w|^\$]/g
 
 export const VARIABLES_SEPARATOR = '_'

--- a/src/templates/service.mustache
+++ b/src/templates/service.mustache
@@ -33,13 +33,14 @@ export default class {{name}} {
         {{/header}}
       },
       {{/header.length}}
-      {{#body.length}}
       {{#body}}
-      body: {
-        {{>alias}}
-      },
+      {{^alias}}
+      body:{{{name}}},
+      {{/alias}}
+      {{#alias}}
+      body:{{{alias}}},
+      {{/alias}}
       {{/body}}
-      {{/body.length}}
       {{#query.length}}
       query: {
       {{#query}}


### PR DESCRIPTION
JavaScript [RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) objects are stateful when they have the [global](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global) or [sticky](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) flags set (e.g. /foo/g or /foo/y). They store a [lastIndex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) from the previous match. Using this internally, exec() can be used to iterate over multiple matches in a string of text (with capture groups), as opposed to getting just the matching strings with [String.prototype.match()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match).

A newer function has been proposed to simplify matching multiple parts of a string (with capture groups): [String.prototype.matchAll()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll).

If you are executing a match to find true or false, use [RegExp.prototype.test()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) method instead.

If you are executing a match to find its index position in the string, use [String.prototype.search()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search) method instead.